### PR TITLE
Copy build output to Revit Addins folder

### DIFF
--- a/ProcoreRevitLink.vbproj
+++ b/ProcoreRevitLink.vbproj
@@ -15,4 +15,8 @@
       <Private>false</Private>
     </Reference>
   </ItemGroup>
+  <Target Name="AfterBuild">
+    <MakeDir Directories="C:\Users\jonathan\AppData\Roaming\Autodesk\Revit\Addins\2023" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="C:\Users\jonathan\AppData\Roaming\Autodesk\Revit\Addins\2023" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- copy plugin DLL to Revit Addins directory after build via `AfterBuild` target

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68add6fb679083279fd11967e2988850